### PR TITLE
Kept method call return consistency.

### DIFF
--- a/src/onelogin/saml2/auth.py
+++ b/src/onelogin/saml2/auth.py
@@ -131,6 +131,7 @@ class OneLogin_Saml2_Auth(object):
                 self.__errors.append('logout_not_success')
             elif not keep_local_session:
                 OneLogin_Saml2_Utils.delete_local_session(delete_session_cb)
+            return self.__request_data['get_data'].get('RelayState') or '/'
 
         elif 'get_data' in self.__request_data and 'SAMLRequest' in self.__request_data['get_data']:
             logout_request = OneLogin_Saml2_Logout_Request(self.__settings, self.__request_data['get_data']['SAMLRequest'])


### PR DESCRIPTION
When the request is a SAMLRequest, the method process_slo returns a url
that should be used as redirect; this changes keeps this behavior for
SAMLResponse requests and also returns a url, in this case it is either
RelayStatus or /.